### PR TITLE
PKG: Include license file in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include COPYING.txt
+include LICENSE


### PR DESCRIPTION
The previously referred file `COPYING.txt` does not exist.